### PR TITLE
Allow compilation under Linux

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -448,14 +448,12 @@ if(EXPAT_BUILD_TESTS)
         endif()
     endfunction()
 
-    add_executable(runtests tests/runtests.c ${test_SRCS})
+    add_executable(runtests tests/runtests.c ${test_SRCS} ${expat_SRCS})
     set_property(TARGET runtests PROPERTY RUNTIME_OUTPUT_DIRECTORY tests)
-    target_link_libraries(runtests expat)
     expat_add_test(runtests $<TARGET_FILE:runtests>)
 
-    add_executable(runtestspp tests/runtestspp.cpp ${test_SRCS})
+    add_executable(runtestspp tests/runtestspp.cpp ${test_SRCS} ${expat_SRCS})
     set_property(TARGET runtestspp PROPERTY RUNTIME_OUTPUT_DIRECTORY tests)
-    target_link_libraries(runtestspp expat)
     expat_add_test(runtestspp $<TARGET_FILE:runtestspp>)
 endif()
 

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -909,6 +909,19 @@ usage(const XML_Char *prog, int rc) {
 int wmain(int argc, XML_Char **argv);
 #endif
 
+#define XMLWF_SHIFT_ARG_INTO(constCharStarTarget, argc, argv, i, j)            \
+  {                                                                            \
+    if (argv[i][j + 1] == T('\0')) {                                           \
+      if (++i == argc)                                                         \
+        usage(argv[0], XMLWF_EXIT_USAGE_ERROR);                                \
+      constCharStarTarget = argv[i];                                           \
+    } else {                                                                   \
+      constCharStarTarget = argv[i] + j + 1;                                   \
+    }                                                                          \
+    i++;                                                                       \
+    j = 0;                                                                     \
+  }
+
 int
 tmain(int argc, XML_Char **argv) {
   int i, j;


### PR DESCRIPTION
Add the missing bits and pieces in order to compile everything successfully.

Tested under Ubuntu Linux 18.04 x86_64.

Please note I did not check that executables and library work... but just that they can be compiled.